### PR TITLE
cache message in wechat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # InfoGPT changelog
 
+### v0.0.10
+
+1. 没有开启企业认证的微信公众号，聊天消息超时缓存
+   说明：根据微信文档 [被动回复用户消息](https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Passive_user_reply_message.html)，第三方服务要在 5 秒内响应用户的消息，而聊天模型的响应时间**普便**超过 5 秒，因为为了`提供较好的体验`，超过 5 秒没有响应，我们会把用户的聊天缓存，等有结果了再返回
+2. 返回消息过长，自动分割
+
 ### v0.0.9
 
 1. telegram bot 支持按照用户 id ratelimit

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ help:
 
 .DEFAULT_GOAL := help
 
+.PHONY: dev
 dev:build
 	./bin/infogpt -conf ~/.kconfigs/infogpt_dev
 

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.0.7 h1:muncTPStnKRos5dpVKULv2FVd4bMOhNePj9CjgDb8Us=
 github.com/pelletier/go-toml/v2 v2.0.7/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,0 +1,19 @@
+package model
+
+import "time"
+
+// WeChatMessageCacheItem 用于缓存的微信公众号聊天消息
+type WeChatMessageCacheItem struct {
+	Message    string    // 原始消息压缩后
+	Replay     string    // openai返回的消息
+	Status     string    // 消息的处理进度
+	ChatTime   time.Time // 聊天发生的时间
+	ReplayTime time.Time // openai返回时间
+}
+
+const (
+	WechatMessageStatusInit    = "init"    // 微信消息状态：刚初始化
+	WechatMessageStatusRequest = "request" // 微信消息状态：刚初始化
+	WechatMessageStatusError   = "error"   // 微信消息状态：openai返回，完成
+	WechatMessageStatusDone    = "done"    // 微信消息状态：openai返回，完成
+)

--- a/library/constants.go
+++ b/library/constants.go
@@ -5,4 +5,5 @@ const (
 	OpenAIBaseAPI                          = "https://api.openai.com"
 	HTTPClientProxyTimeoutS                = 15
 	WeChatOfficialAccountEncodingAesKeyLen = 43
+	WeChatReplayMessageLen                 = 600
 )

--- a/library/utils.go
+++ b/library/utils.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"time"
 )
 
 func PrintJson(title string, v interface{}) {
@@ -26,4 +27,10 @@ func CheckUrl(urlStr string) error {
 // 当前主要是去掉首尾空格
 func CompressMessage(msg string) string {
 	return strings.TrimSpace(msg)
+}
+
+const StandardTimeLayout = "2006-01-02 15:04:05"
+
+func StandardTimeString(t time.Time) string {
+	return t.Format(StandardTimeLayout)
 }


### PR DESCRIPTION
### v0.0.10

1. 没有开启企业认证的微信公众号，聊天消息超时缓存
   说明：根据微信文档 [被动回复用户消息](https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Passive_user_reply_message.html)，第三方服务要在 5 秒内响应用户的消息，而聊天模型的响应时间**普便**超过 5 秒，因为为了`提供较好的体验`，超过 5 秒没有响应，我们会把用户的聊天缓存，等有结果了再返回
2. 返回消息过长，自动分割
